### PR TITLE
Reintroduce workaround for arm64 to use rosetta

### DIFF
--- a/copyPlatformBinaryInPlace.js
+++ b/copyPlatformBinaryInPlace.js
@@ -13,6 +13,11 @@ if (platform === "win32") {
   platform = "win";
 }
 
+// Workaround for arm64 to use Rosetta for now
+if (arch === "arm64") {
+  arch = "x64";
+}
+
 copyBinary("bin/graphql-ppx-" + platform + "-" + arch + ".exe", "ppx");
 
 function copyBinary(filename, destFilename) {


### PR DESCRIPTION
HI @jfrolich and graphql-ppx team!

I would like to open a pull request to reintroduce this work around for arm64 macs to be able to use rosetta. 

I'm not entirely sure what the reasoning for removing this workaround was on the latest update but I would be a very appreciative developer if it could be reintroduced.

I have also modified the `if` statement to only check whether process.arch is `"arm64"` and not to specifically require process.platform to equal `"darwin"`. This is because using the new optimized docker for apple silicon one could be running a container with linux in an arm64 environment for example and it would still work perfectly using the graphql-ppx-linux-x64.exe.

This has been the case for me on a current project and I've had code in a virtual environment in order to work with graphql-ppx.

Thanks very much.